### PR TITLE
Create hanovernorwichschools.txt

### DIFF
--- a/lib/domains/br/simonsen.txt
+++ b/lib/domains/br/simonsen.txt
@@ -1,0 +1,1 @@
+Faculdades Integradas Simonsen

--- a/lib/domains/fr/insta.txt
+++ b/lib/domains/fr/insta.txt
@@ -1,0 +1,1 @@
+institut de technologies avancées

--- a/lib/domains/net/jhs.txt
+++ b/lib/domains/net/jhs.txt
@@ -1,0 +1,1 @@
+Jesuit High School

--- a/lib/domains/ru/mgupp.txt
+++ b/lib/domains/ru/mgupp.txt
@@ -1,0 +1,1 @@
+Moscow State University of Food Production

--- a/lib/domains/us/pa/k12/gmsd.txt
+++ b/lib/domains/us/pa/k12/gmsd.txt
@@ -1,0 +1,1 @@
+Governor Mifflin School District


### PR DESCRIPTION
School website is hanoverhigh.us, but we use hanovernorichschools.org for our district email.
